### PR TITLE
- added direct CLI usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 cli = ["click"]
 
+[project.scripts]
+phub-cli = "phub.__main__:main"
+
 [project.urls]
 Documentation = "https://phub.readthedocs.io"
 Repository = "https://github.com/EchterAlsFake/PHUB"

--- a/src/phub/__main__.py
+++ b/src/phub/__main__.py
@@ -2,8 +2,15 @@
 PHUB built-in CLI.
 '''
 import os
-import click
 import phub
+
+try:
+    import click
+
+except (ModuleNotFoundError, ImportError):
+    print("The CLI needs 'click' in order to work. Please do: 'pip install click'")
+    exit()
+
 
 @click.command()
 @click.argument('input')


### PR DESCRIPTION
- making PHUB directly executable as a CLI using `phub-cli`
- needs `click` as an optional requirement