### PR TITLE
Fix/video title sanitization

### DIFF
--- a/src/phub/__main__.py
+++ b/src/phub/__main__.py
@@ -33,7 +33,7 @@ def download_video(client: Client, url: [str, Video], output: str, quality: str,
     else:
         raise "Some error happened here, please report on GitHub, thank you :) "
 
-    title = video.title
+    title =  re.sub(r'[<>:"/\\|?*]', '', video.title)
     final_output_path = os.path.join(output, title + ".mp4")
 
     print(f"Downloading: {title} to: {final_output_path}")

--- a/src/phub/__main__.py
+++ b/src/phub/__main__.py
@@ -4,6 +4,7 @@ PHUB built-in CLI.
 
 import os
 import argparse
+import re
 
 from phub import Client, Video
 from phub.modules.download import threaded, FFMPEG, default


### PR DESCRIPTION
Remove illegal characters from the filename of the saved video.

Characters picked up from the video title can sometimes be illegal (and cannot be escaped, afaik) in Windoze filenames and will result in an exception when trying to save as such.